### PR TITLE
feat: use env variables for api url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode/
 /build
+.env

--- a/src/routes/roots.js
+++ b/src/routes/roots.js
@@ -1,11 +1,11 @@
-const baseURL = "https://bde-api.cluster-ig3.igpolytech.fr";
+const baseURL = process.env.REACT_APP_API_URL;
 
-export const clubs = baseURL + "/api/clubs/";
-export const events = baseURL + "/api/events/";
-export const goodies = baseURL + "/api/goodies/";
-export const partners = baseURL + "/api/partners/";
-export const promos = baseURL + "/api/promos/";
-export const users = baseURL + "/api/users/";
-export const roles = baseURL + "/api/roles/";
-export const signup = baseURL + "/api/signup/";
-export const signin = baseURL + "/api/signin/";
+export const clubs = baseURL + '/api/clubs/';
+export const events = baseURL + '/api/events/';
+export const goodies = baseURL + '/api/goodies/';
+export const partners = baseURL + '/api/partners/';
+export const promos = baseURL + '/api/promos/';
+export const users = baseURL + '/api/users/';
+export const roles = baseURL + '/api/roles/';
+export const signup = baseURL + '/api/signup/';
+export const signin = baseURL + '/api/signin/';


### PR DESCRIPTION
This is useful for development with a local api.

I think you should add `REACT_APP_API_URL=https://bde-api.cluster-ig3.igpolytech.fr` in your heroku environment variables before deploying this branch.

To use it with your api running locally => Create a .env file with `REACT_APP_API_URL=http://localhost:8000`